### PR TITLE
NEW Add validation for "add item" requests, implement maximum item quantity in cart

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,5 @@ indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[{*.yml,package.json}]
+[{*.yml,package.json,*.scss,*.css,*.js}]
 indent_size = 2

--- a/css/dms-cart.css
+++ b/css/dms-cart.css
@@ -1,8 +1,3 @@
-.dms-cart-actions .hidden {
-    display: none;
-    visibility: hidden;
-}
-
-.dms-cart-actions .dms-bullet-item:before {
-    content: "• "
+.dms-cart-actions .dms-cart-actions-viewcartlink:before {
+  content: "• "
 }

--- a/javascript/dmscart.js
+++ b/javascript/dmscart.js
@@ -1,0 +1,30 @@
+(function ($) {
+  "use strict";
+
+  $.entwine('ss', function ($) {
+    $('input.dms-allowed-in-cart').entwine({
+      /**
+       * Toggle the "maximum cart quantity" field visibility depending on whether "allowed in document cart" is checked
+       */
+      onclick: function (e) {
+        jQuery('.field.dms-maximum-cart-quantity').toggle();
+        this.getElements().removeClass('hide');
+      },
+      /**
+       * Initially show the "maximum cart quantity" field visibility if the "allowed in document cart" checkbox
+       * is checked
+       */
+      onmatch: function(e) {
+        if (this.is(':checked')) {
+          this.getElements().removeClass('hide');
+        }
+      },
+      /**
+       * Returns all DOM elements with the field's class applied
+       */
+      getElements: function() {
+        return jQuery('.dms-maximum-cart-quantity');
+      }
+    });
+  });
+}(jQuery));

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,0 +1,8 @@
+en:
+  DMSDocumentCart:
+    ALLOWED_IN_CART: Allowed in document cart
+    MAXIMUM_CART_QUANTITY: Maximum cart quantity
+    MAXIMUM_CART_QUANTITY_HELP: If set, this will enforce a maximum number of this item that can be ordered per cart
+  DMSDocumentCartController:
+    ERROR_NOT_ALLOWED: You are not allowed to add this document
+    ERROR_QUANTITY_EXCEEDED: You can't add {quantity} of this document

--- a/templates/includes/CartActions.ss
+++ b/templates/includes/CartActions.ss
@@ -2,15 +2,23 @@
     <% require css('dms-cart/css/dms-cart.css') %>
 
     <div class="dms-cart-actions">
+        <% if $getValidationResult %>
+            <form>
+                <p class="message dms-cart-actions-messages bad">$getValidationResult</p>
+            </form>
+        <% end_if %>
         <p>
-            <a class="<% if not $isInCart %>hidden<% end_if %>"
-               href="$getActionLink('remove')"><%t DMSCart.REMOVE_FROM_CART "Remove from cart" %> </a>
-            <a class="<% if $isInCart %>hidden<% end_if %>"
-               href="$getActionLink('add')"><%t DMSCart.ADD_TO_CART "Request a printed copy" %> </a>
             <% if $isInCart %>
-                <a class="dms-bullet-item <% if not $isInCart %>hidden<% end_if %>" href="$getActionLink('checkout')"
+                <a class="dms-cart-actions-removelink" href="$getActionLink('remove')">
+                    <%t DMSCart.REMOVE_FROM_CART "Remove from cart" %>
+                </a>
+                <a class="dms-cart-actions-viewcartlink" href="$getActionLink('checkout')"
                    title="<%t DMSCart.VIEW_MY_CART "View my Document cart" %>"
                 ><%t DMSCart.VIEW_MY_CART "View my Document cart" %></a>
+            <% else %>
+                <a class="dms-cart-actions-addlink" href="$getActionLink('add')">
+                    <%t DMSCart.ADD_TO_CART "Request a printed copy" %>
+                </a>
             <% end_if %>
         </p>
     </div>

--- a/tests/DMSDocumentCartControllerTest.php
+++ b/tests/DMSDocumentCartControllerTest.php
@@ -158,4 +158,25 @@ class DMSDocumentCartControllerTest extends FunctionalTest
         //For good measure assert it's empty
         $this->assertTrue($this->controller->getIsCartEmpty());
     }
+
+    /**
+     * Ensure that a validation error is shown when requesting to add more of a document that is allowed
+     */
+    public function testCannotAddMoreThanSuggestedQuantityOfItem()
+    {
+        $document = $this->objFromFixture('DMSDocument', 'limited_supply');
+        $result = $this->get('/documentcart/add/' . $document->ID . '?quantity=5&ajax=1');
+        $this->assertContains('You can\'t add 5 of this document', (string) $result->getBody());
+    }
+
+    /**
+     * Ensure that when a document that cannot be added to the cart is added to the cart, a validation error is
+     * returned
+     */
+    public function testValidationErrorReturnedOnInvalidAdd()
+    {
+        $document = $this->objFromFixture('DMSDocument', 'not_allowed_in_cart');
+        $result = $this->get('/documentcart/add/' . $document->ID . '?ajax=1');
+        $this->assertContains('You are not allowed to add this document', (string) $result->getBody());
+    }
 }

--- a/tests/DMSDocumentCartTest.yml
+++ b/tests/DMSDocumentCartTest.yml
@@ -11,6 +11,15 @@ DMSDocument:
   doc2:
     Filename: Doc2
     Title: Doc2
+  limited_supply:
+    Filename: Doc3
+    Title: Doc3
+    AllowedInCart: 1
+    MaximumCartQuantity: 3
+  not_allowed_in_cart:
+    Filename: Doc4
+    Title: Doc4
+    AllowedInCart: 0
 DMSDocumentCartCheckoutPage:
   page1:
     ThanksMessage: Thank you for your submission

--- a/tests/extensions/DMSDocumentCartExtensionTest.php
+++ b/tests/extensions/DMSDocumentCartExtensionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+class DMSDocumentCartExtensionTest extends SapphireTest
+{
+    protected $requiredExtensions = array(
+        'DMSDocument' => array('DMSDocumentCartExtension')
+    );
+
+    public function testMaximumCartQuantity()
+    {
+        $document = DMSDocument::create(array('AllowedInCart' => true, 'MaximumCartQuantity' => ''));
+
+        $this->assertFalse($document->getHasQuantityLimit());
+
+        $document->MaximumCartQuantity = 0;
+        $this->assertFalse($document->getHasQuantityLimit());
+
+        $document->MaximumCartQuantity = 1;
+        $this->assertTrue($document->getHasQuantityLimit());
+        $this->assertSame(1, $document->getMaximumQuantity());
+
+        $document->MaximumCartQuantity = 10;
+        $this->assertSame(10, $document->getMaximumQuantity());
+    }
+
+    /**
+     * The CSS classes are required for the CMS Javascript to work, assert that they are correct
+     */
+    public function testCmsFieldsHaveRequiredCssClasses()
+    {
+        $fields = DMSDocument::create()->getCMSFields();
+
+        $allowedInCart = $fields->fieldByName('AllowedInCart');
+        $this->assertInstanceOf('CheckboxField', $allowedInCart);
+        $this->assertTrue((bool) $allowedInCart->hasClass('dms-allowed-in-cart'));
+
+        $allowedInCart = $fields->fieldByName('MaximumCartQuantity');
+        $this->assertInstanceOf('TextField', $allowedInCart);
+        $this->assertTrue((bool) $allowedInCart->hasClass('dms-maximum-cart-quantity'));
+    }
+
+    /**
+     * Ensure that validation messages can be retrieved once, cleared, then not again
+     */
+    public function testGetValidationResult()
+    {
+        Session::set('dms-cart-validation-message', 'testing');
+        $this->assertSame('testing', DMSDocument::create()->getValidationResult());
+        $this->assertFalse(DMSDocument::create()->getValidationResult());
+    }
+}


### PR DESCRIPTION
Resolves #9

Please note: As mentioned in #9 this doesn't validate anything on the quantity fields on the checkout page. This will be moved to a submitted form that will call the cart controller's "add" method, which would then use this new validation. For now it's not validated.