### PR TITLE
API Make submission items store persistent data instead of dynamic relationship

### DIFF
--- a/code/classes/DMSDocumentCart.php
+++ b/code/classes/DMSDocumentCart.php
@@ -262,15 +262,17 @@ class DMSDocumentCart extends ViewableData
         $submission = DMSDocumentCartSubmission::create();
         $form->saveInto($submission);
         $return = $submission->write();
-        $this->getItems()->each(function ($row) use ($submission) {
-            $values = array(
-                'Quantity' => $row->getQuantity(),
-                'DocumentID' => $row->getDocument()->ID,
-            );
-            $submissionItem = DMSDocumentCartSubmissionItem::create($values);
+        $this->getItems()->each(function ($item) use ($submission) {
+            /** @var DMSDocument $document */
+            $document = $item->getDocument();
+            $submissionItem = DMSDocumentCartSubmissionItem::create(array(
+                'OriginalID' => $document->ID,
+                'Quantity' => $item->getQuantity(),
+                'Title' => $document->getTitle(),
+                'Filename' => $document->getFilenameWithoutID()
+            ));
             $submission->Items()->add($submissionItem);
-
-            $row->getDocument()->incrementPrintRequest();
+            $document->incrementPrintRequest();
         });
 
         return $return;

--- a/code/controllers/DMSCheckoutController.php
+++ b/code/controllers/DMSCheckoutController.php
@@ -65,8 +65,9 @@ class DMSCheckoutController extends DMSCartAbstractController
         $fields->replaceField('DeliveryAddressLine2', TextField::create('DeliveryAddressLine2', ''));
         $fields->replaceField('DeliveryAddressCountry', CountryDropdownField::create(
             'DeliveryAddressCountry',
-            _t(__CLASS__ . '.RECEIVER_COUNTRY', 'Country')
+            _t('DMSCheckoutController.RECEIVER_COUNTRY', 'Country')
         )->setValue('NZ'));
+        $fields->removeByName('CreatedAt');
 
         $requiredFields = array(
             'ReceiverName',
@@ -85,7 +86,7 @@ class DMSCheckoutController extends DMSCartAbstractController
         $actions = FieldList::create(
             FormAction::create(
                 'doRequestSend',
-                _t(__CLASS__ . '.SEND_ACTION', 'Send your request')
+                _t('DMSCheckoutController.SEND_ACTION', 'Send your request')
             )
         );
 
@@ -123,7 +124,7 @@ class DMSCheckoutController extends DMSCartAbstractController
         $email = Email::create(
             $from,
             $emailAddress,
-            _t(__CLASS__ . '.EMAIL_SUBJECT', 'Request for Printed Publications')
+            _t('DMSCheckoutController.EMAIL_SUBJECT', 'Request for Printed Publications')
         );
 
         if ($bcc = $this->getConfirmationBcc()) {
@@ -134,7 +135,7 @@ class DMSCheckoutController extends DMSCartAbstractController
         $body = sprintf(
             '<p>%s</p>',
             _t(
-                __CLASS__ . '.EMAIL_BODY',
+                'DMSCheckoutController.EMAIL_BODY',
                 'A request for printed publications has been submitted with the following details:'
             )
         );

--- a/code/models/DMSDocumentCartSubmissionItem.php
+++ b/code/models/DMSDocumentCartSubmissionItem.php
@@ -3,26 +3,37 @@
 class DMSDocumentCartSubmissionItem extends DataObject
 {
     private static $db = array(
+        'OriginalID' => 'Int',
+        'Title' => 'Varchar(255)',
+        'Filename' => 'Varchar(255)',
         'Quantity' => 'Int',
     );
 
     private static $has_one = array(
-        'Document'                  => 'DMSDocument',
         'DMSDocumentCartSubmission' => 'DMSDocumentCartSubmission',
     );
 
-    private static $summary_fields = array(
-        'Document.getTitle' => 'Document',
-        'Quantity' => 'Quantity'
-    );
+    private static $summary_fields = array('Title', 'Filename', 'Quantity');
 
     private static $singular_name = 'Submission Item';
     private static $plural_name = 'Submission Items';
 
     public function getCMSFields()
     {
-        $fields = parent::getCMSFields();
-        $fields->removeByName('DMSDocumentCartSubmissionID');
-        return $fields;
+        $this->beforeUpdateCMSFields(function (FieldList $fields) {
+            $fields->removeByName('DMSDocumentCartSubmissionID');
+
+            $fields->addFieldToTab(
+                'Root.Main',
+                $fields->fieldByName('Root.Main.OriginalID')
+                    ->performReadonlyTransformation()
+                    ->setDescription(_t(
+                        'DMSDocumentCartSubmissionItem.ORIGINALIDHELPTIP',
+                        'Note: The original document may have been modified or removed since this request was made.'
+                    )),
+                'Title'
+            );
+        });
+        return parent::getCMSFields();
     }
 }

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -20,3 +20,5 @@ en:
     EMAIL_SUBJECT: Request for Printed Publications
     RECEIVER_COUNTRY: Country
     SEND_ACTION: Send your request
+  DMSDocumentCartSubmissionItem:
+    ORIGINALIDHELPTIP: 'Note: The original document may have been modified or removed since this request was made.'

--- a/templates/includes/DocumentCart_email.ss
+++ b/templates/includes/DocumentCart_email.ss
@@ -4,7 +4,7 @@
         <thead>
         <tr>
             <th colspan="2">
-                <%t DMSCart.DELIVERY_INFORMATION "Delivery Information" %>
+                <%t DMSDocumentCartSubmission.DELIVERY_INFORMATION "Delivery Information" %>
             </th>
         </tr>
         </thead>
@@ -12,25 +12,25 @@
             <% with $ReceiverInfoNice %>
             <tr>
                 <td>
-                    <%t DMSCart.RECEIVER_NAME "Name" %>
+                    <%t DMSDocumentCartSubmission.RECEIVER_NAME "Name" %>
                 </td>
                 <td>$ReceiverName.XML</td>
             </tr>
             <tr>
                 <td>
-                    <%t DMSCart.RECEIVER_PHONE "Phone" %>
+                    <%t DMSDocumentCartSubmission.RECEIVER_PHONE "Phone" %>
                 </td>
                 <td>$ReceiverPhone.XML</td>
             </tr>
             <tr>
                 <td>
-                    <%t DMSCart.RECEIVER_EMAIL "Email" %>
+                    <%t DMSDocumentCartSubmission.RECEIVER_EMAIL "Email" %>
                 </td>
                 <td>$ReceiverEmail.XML</td>
             </tr>
             <tr>
                 <td>
-                    <%t DMSCart.RECEIVER_ADDRESS "Shipping Address" %>
+                    <%t DMSDocumentCartSubmission.RECEIVER_ADDRESS "Shipping Address" %>
                 </td>
                 <td>
                     $DeliveryAddressLine1.XML<br/>

--- a/templates/includes/RequestItems_email.ss
+++ b/templates/includes/RequestItems_email.ss
@@ -1,39 +1,25 @@
-<table title="<%t DMSCart.TABLE_TITLE "Requested documents" %>" style="text-align:left; width:100%;">
+<table title="<%t DMSDocumentCartSubmissionItem.TABLE_TITLE "Requested documents" %>" style="text-align:left; width:100%;">
     <thead>
     <tr>
         <th>
-            <%t DMSCart.TITLE "Title" %>
+            <%t DMSDocumentCartSubmissionItem.TITLE "Title" %>
         </th>
         <th>
-            <%t DMSCart.FILE_NAME "File name" %>
+            <%t DMSDocumentCartSubmissionItem.FILE_NAME "File name" %>
         </th>
         <th>
-            <%t DMSCart.TOTAL_COPIES "# of copies" %>
-        </th>
-        <th>
-            <%t DMSCart.TYPE "Type" %>
-        </th>
-        <th>
-            <%t DMSCart.SIZE "Size" %>
-        </th>
-        <th>
-            <%t DMSCart.URL "URL" %>
+            <%t DMSDocumentCartSubmissionItem.TOTAL_COPIES "# of copies" %>
         </th>
     </tr>
     </thead>
     <tbody>
         <% loop $Items %>
         <tr>
-            <% with $Document %>
-                <td>$Title</td>
-                <td>$FilenameWithoutID</td>
-                <td>$Up.Quantity</td>
-                <td>$Extension.UpperCase</td>
-                <td>$Size</td>
-                <td>
-                    <a href="$Link"><%t DMSCart.VIEW_DOCUMENT "View Document" %></a>
-                </td>
+            <% with $getDocument %>
+            <td>$Title</td>
+            <td>$FilenameWithoutID</td>
             <% end_with %>
+            <td>$Quantity</td>
         </tr>
         <% end_loop %>
     </tbody>

--- a/tests/models/DMSDocumentCartSubmissionItemTest.php
+++ b/tests/models/DMSDocumentCartSubmissionItemTest.php
@@ -10,4 +10,15 @@ class DMSDocumentCartSubmissionItemTest extends SapphireTest
         $fields = DMSDocumentCartSubmissionItem::create()->getCMSFields();
         $this->assertNull($fields->fieldByName('DMSDocumentCartSubmissionID'));
     }
+
+    /**
+     * The "original ID" field points to the initial ID of the document that was ordered at the time it was placed.
+     * This can easily change, so test that we have a helptip to say this. It should also be read only.
+     */
+    public function testOriginalIdFieldHasHelptipAndIsReadonly()
+    {
+        $field = DMSDocumentCartSubmissionItem::create()->getCMSFields()->fieldByName('Root.Main.OriginalID');
+        $this->assertInstanceOf('ReadonlyField', $field);
+        $this->assertContains('The original document may have been modified', $field->getDescription());
+    }
 }

--- a/tests/models/DMSDocumentCartSubmissionTest.php
+++ b/tests/models/DMSDocumentCartSubmissionTest.php
@@ -2,6 +2,8 @@
 
 class DMSDocumentCartSubmissionTest extends SapphireTest
 {
+    protected $usesDatabase = true;
+
     /**
      * Test that the add new and existing GridField components have been removed
      */
@@ -14,5 +16,28 @@ class DMSDocumentCartSubmissionTest extends SapphireTest
         $config = $gridField->getConfig();
         $this->assertNull($config->getComponentByType('GridFieldAddExistingAutocompleter'));
         $this->assertNull($config->getComponentByType('GridFieldAddNewButton'));
+    }
+
+    /**
+     * Ensure that a "created at" date is set when a record is created
+     */
+    public function testCreatedAtIsSetOnWrite()
+    {
+        $submission = DMSDocumentCartSubmission::create();
+        $this->assertNull($submission->CreatedAt);
+
+        $submission->write();
+        $this->assertNotNull($submission->CreatedAt);
+    }
+
+    /**
+     * Ensure that the scaffolded "created at" is readonly in the CMS
+     */
+    public function testCreatedAtIsReadonly()
+    {
+        $submission = DMSDocumentCartSubmission::create();
+        $submission->write();
+        $fields = $submission->getCMSFields();
+        $this->assertInstanceOf('DatetimeField_Readonly', $fields->fieldByName('Root.Main.CreatedAt'));
     }
 }


### PR DESCRIPTION
* Replace `__CLASS__` in translations
* Use `beforeUpdateCMSFields` callback to modify CMS fields in submission and items
* Add `CreatedAt` to Submission, add to summary for grid fields

Resolves #39 